### PR TITLE
[Future] Fix type error

### DIFF
--- a/src/Future.ts
+++ b/src/Future.ts
@@ -186,7 +186,7 @@ export namespace Future {
     }
 
     export function failed<A>(e: Error): Future<A> {
-        return new FutureImpl<A>(<Promise<A>>Promise.reject(e), Failure<A>(e));
+        return new FutureImpl<A>(<Promise<A>>Promise.reject<A>(e), Failure<A>(e));
     }
 
     export function successful<A>(a: A): Future<A> {
@@ -292,15 +292,15 @@ class FutureImpl<A> implements Future<A> {
         try {
             return f();
         } catch (e) {
-            return <Promise<B>>Promise.reject(e);
+            return <Promise<B>>Promise.reject<B>(e);
         }
     }
 
     transform<B>(f: (t: Try<A>) => Try<B>): Future<B> {
         return new FutureImpl(
             this.promise.then<B>(
-                a => this.tryPromise(() => f(Success(a)).fold((e) => <Promise<B>>Promise.reject(e), (b) => Promise.resolve(b))),
-                e => this.tryPromise(() => f(Failure<A>(e)).fold((e) => <Promise<B>>Promise.reject(e), (b) => Promise.resolve(b)))
+                a => this.tryPromise(() => f(Success(a)).fold((e) => <Promise<B>>Promise.reject<B>(e), (b) => Promise.resolve(b))),
+                e => this.tryPromise(() => f(Failure<A>(e)).fold((e) => <Promise<B>>Promise.reject<B>(e), (b) => Promise.resolve(b)))
             )
         );
     }


### PR DESCRIPTION
This is just to avoid this message : 

`node_modules/scalts/src/Future.ts(189,34): error TS2352: Type 'Promise<void>' cannot be converted to type 'Promise<A>'.
  Type 'void' is not comparable to type 'A'.
node_modules/scalts/src/Future.ts(295,20): error TS2352: Type 'Promise<void>' cannot be converted to type 'Promise<B>'.
  Type 'void' is not comparable to type 'B'.
node_modules/scalts/src/Future.ts(302,70): error TS2352: Type 'Promise<void>' cannot be converted to type 'Promise<B>'.
  Type 'void' is not comparable to type 'B'.
node_modules/scalts/src/Future.ts(303,73): error TS2352: Type 'Promise<void>' cannot be converted to type 'Promise<B>'.
  Type 'void' is not comparable to type 'B'.`
