### PR TITLE
Typescript v2 migration

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,1 @@
+export * from './src/scalts';

--- a/package.json
+++ b/package.json
@@ -2,17 +2,13 @@
   "name": "scalts",
   "version": "0.4.0-beta2",
   "description": "Typescript libraries with some functional items",
-  "main": "./src/scalts.js",
-  "types": "./src/scalts.d.ts",
+  "main": "./src/scalts.ts",
   "scripts": {
     "main": "tsc",
     "prepublish": "npm test",
     "cover": "tsc && istanbul cover -x '**/logger.*' _mocha test/**/*.js",
     "cover:publish": "CODECLIMATE_REPO_TOKEN=3a735fa909712074d569bbc8a7bd195dfddc064138d245b3e799cef1ebbefa97 codeclimate-test-reporter < ./coverage/lcov.info",
     "test": "npm run cover"
-  },
-  "typescript": {
-    "definition": "src/scalts.d.ts"
   },
   "files": [
     "src",


### PR DESCRIPTION
You don't need to put all that stuff in your package.json now. 
My IDE (webstorm) was not able to find the scalts project when using it in an other project while it was compiling. I needed to put an index.ts at the root of the project.
I also needed to put a main file with an extension in ".ts" in the package.json, otherwise, my IDE was not able to find types.